### PR TITLE
fix pipeline error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setup(
     name="scp_crawler",
     version="1.0",
     packages=find_packages(),
-    entry_points={"scrapy": ["settings = scp_crawler.settings"], "console_scripts": ["scp_pp = scp_crawler.postprocessing"]},
+    entry_points={"scrapy": ["settings = scp_crawler.settings"], "console_scripts": ["scp_pp = scp_crawler:postprocessing"]},
     install_requires=["Scrapy", "beautifulsoup4", "tqdm", "httpx", "typer"],
 )


### PR DESCRIPTION
From https://github.com/scp-data/scp-api/actions/runs/7175569848 

ERROR: For req: scp-crawler==1.0. Invalid script entry point: <ExportEntry scp_pp = scp_crawler.postprocessing:None []> - A callable suffix is required.