### PR TITLE
Add Supplements spider + integrated crawling/postprocessing

### DIFF
--- a/.github/workflows/scp-items.yml
+++ b/.github/workflows/scp-items.yml
@@ -1,17 +1,19 @@
 name: Crawl SCP Wiki
 
 on:
-#   workflow_dispatch:
+  workflow_dispatch:
 #   schedule:
 #     - cron: "0 0 * * *"
-  push:
+  # push:
+    # branches:
+    #   - main
+    # paths:
+    #   - .github/workflows/scp-items.yml
+  pull_request:
     branches:
       - main
     paths:
       - .github/workflows/scp-items.yml
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write

--- a/.github/workflows/scp-items.yml
+++ b/.github/workflows/scp-items.yml
@@ -1,0 +1,92 @@
+name: Crawl SCP Wiki
+
+on:
+#   workflow_dispatch:
+#   schedule:
+#     - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/scp-items.yml
+
+permissions:
+  contents: write
+
+jobs:
+  update-main-scp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Clone this Repository"
+        uses: actions/checkout@v6
+        with:
+          path: scp-api
+
+      - name: "Clone the Crawler"
+        uses: actions/checkout@v6
+        with:
+          repository: heroheman/scp_crawler
+          ref: "main"
+          path: scp-crawler
+
+      - name: "Setup Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: "Install Crawler"
+        working-directory: ./scp-crawler
+        run: make install
+
+      - name: "Crawl Titles"
+        working-directory: ./scp-crawler
+        run: make data/scp_titles.json
+
+      - name: "Crawl Hubs"
+        working-directory: ./scp-crawler
+        run: make data/scp_hubs.json
+
+      - name: "Crawl Items"
+        working-directory: ./scp-crawler
+        run: make data/scp_items.json
+
+      - name: "Process Items"
+        working-directory: ./scp-crawler
+        run: make data/processed/items
+
+      - name: "Crawl Tales"
+        working-directory: ./scp-crawler
+        run: make data/scp_tales.json
+
+      - name: "Process Tales"
+        working-directory: ./scp-crawler
+        run: make data/processed/tales
+
+      - name: "Crawl GOI"
+        working-directory: ./scp-crawler
+        run: make data/goi.json
+
+      - name: "Process GOI"
+        working-directory: ./scp-crawler
+        run: make data/processed/goi
+
+      - name: "Crawl Supplements"
+        working-directory: ./scp-crawler
+        run: make data/scp_supplement.json
+
+      - name: "Process Supplements"
+        working-directory: ./scp-crawler
+        run: make data/processed/supplement
+
+      - name: "Move Files into API"
+        run: cp -Rf ./scp-crawler/data/processed/* ./scp-api/docs/data/scp/
+
+      - name: "Push"
+        shell: bash
+        run: >
+          cd scp-api;
+          ./bin/push.sh;
+
+        env:
+          GIT_USER: "SCP Bot"
+          GIT_EMAIL: "scp@tedivm.com"

--- a/.github/workflows/scp-items.yml
+++ b/.github/workflows/scp-items.yml
@@ -9,6 +9,9 @@ on:
       - main
     paths:
       - .github/workflows/scp-items.yml
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -17,17 +20,14 @@ jobs:
   update-main-scp:
     runs-on: ubuntu-latest
     steps:
-      - name: "Clone this Repository"
+      - name: "Checkout Crawler"
         uses: actions/checkout@v6
-        with:
-          path: scp-api
 
-      - name: "Clone the Crawler"
+      - name: "Clone API Repository"
         uses: actions/checkout@v6
         with:
-          repository: heroheman/scp_crawler
-          ref: "main"
-          path: scp-crawler
+          repository: heroheman/scp-api
+          path: scp-api
 
       - name: "Setup Python"
         uses: actions/setup-python@v6
@@ -35,58 +35,47 @@ jobs:
           python-version: '3.13'
 
       - name: "Install Crawler"
-        working-directory: ./scp-crawler
         run: make install
 
       - name: "Crawl Titles"
-        working-directory: ./scp-crawler
         run: make data/scp_titles.json
 
       - name: "Crawl Hubs"
-        working-directory: ./scp-crawler
         run: make data/scp_hubs.json
 
       - name: "Crawl Items"
-        working-directory: ./scp-crawler
         run: make data/scp_items.json
 
       - name: "Process Items"
-        working-directory: ./scp-crawler
         run: make data/processed/items
 
       - name: "Crawl Tales"
-        working-directory: ./scp-crawler
         run: make data/scp_tales.json
 
       - name: "Process Tales"
-        working-directory: ./scp-crawler
         run: make data/processed/tales
 
       - name: "Crawl GOI"
-        working-directory: ./scp-crawler
         run: make data/goi.json
 
       - name: "Process GOI"
-        working-directory: ./scp-crawler
         run: make data/processed/goi
 
       - name: "Crawl Supplements"
-        working-directory: ./scp-crawler
         run: make data/scp_supplement.json
 
       - name: "Process Supplements"
-        working-directory: ./scp-crawler
         run: make data/processed/supplement
 
       - name: "Move Files into API"
-        run: cp -Rf ./scp-crawler/data/processed/* ./scp-api/docs/data/scp/
+        run: cp -Rf ./data/processed/* ./scp-api/docs/data/scp/
 
-      - name: "Push"
-        shell: bash
-        run: >
-          cd scp-api;
-          ./bin/push.sh;
+      # - name: "Push"
+      #   shell: bash
+      #   run: >
+      #     cd scp-api;
+      #     ./bin/push.sh;
 
-        env:
-          GIT_USER: "SCP Bot"
-          GIT_EMAIL: "scp@tedivm.com"
+      #   env:
+      #     GIT_USER: "SCP Bot"
+      #     GIT_EMAIL: "scp@tedivm.com"

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 
 *.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,9 +32,15 @@ To crawl the International Hub for SCP Items and save to a custom location:
 scrapy crawl scp_int -o scp_international_items.json
 ```
 
+To crawl pages tagged as `supplement` and save to a custom location:
+
+```bash
+scrapy crawl scp_supplement -o scp_supplement.json
+```
+
 ## Raw Content Structure
 
-There are two types of content downloaded- SCP Items and SCP Tales.
+There are multiple types of content downloaded (Items, Tales, GOI formats, and Supplements).
 
 All content (both SCP Items and Tales) contain the following:
 
@@ -66,6 +72,7 @@ The crawler generates a series of json files containing an array of objects repr
 | scp_titles.json     | Main          | Title | scp     |
 | scp_hubs.json       | Main          | Hub   | scp     |
 | scp_tales.json      | Main          | Tale  | scp     |
+| scp_supplement.json | Main          | Supplement | scp |
 | scp_int.json        | International | Item  | scp_int |
 | scp_int_titles.json | International | Title | scp_int |
 | scp_int_tales.json  | International | Tale  | scp_int |
@@ -76,7 +83,9 @@ To regenerate all files run `make fresh`.
 
 ## Post Processed Data
 
-The postproc system takes the Titles, Hubs, Items, and Tales and uses them to generate a comprehensive set of objects. It combines and cross references data and expands on the data already there.
+The postproc system takes Titles, Hubs, Items, Tales, GOI, and Supplements and uses them to generate a comprehensive set of objects. It combines and cross references data and expands on the data already there.
+
+Supplements are written to `data/processed/supplement/` and include additional fields like `parent_scp` and `parent_tale`.
 
 
 ## Content Licensing

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ PYTHON_VENV = source .venv/bin/activate &&
 
 install: .venv
 
-data: scp scp_int goi
+data: scp scp_int goi supplement
 
 fresh: clean data
 
@@ -14,7 +14,7 @@ clean:
 	python -m venv .venv
 	$(PYTHON_VENV) python -m pip install .
 
-crawl: scp scp_int goi
+crawl: scp scp_int goi supplement
 
 scp: scp_crawl scp_postprocess
 
@@ -36,6 +36,11 @@ goi: data/goi.json
 
 data/goi.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl goi -o data/goi.json
+
+supplement: data/scp_supplement.json
+
+data/scp_supplement.json: .venv
+	$(PYTHON_VENV) python -m scrapy crawl scp_supplement -o data/scp_supplement.json
 
 scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ PYTHON_VENV = source .venv/bin/activate &&
 
 install: .venv
 
-data: scp scp_int goi supplement
+data: scp scp_int goi
 
 fresh: clean data
 
@@ -14,11 +14,11 @@ clean:
 	python -m venv .venv
 	$(PYTHON_VENV) python -m pip install .
 
-crawl: scp scp_int goi supplement
+crawl: scp scp_int goi
 
 scp: scp_crawl scp_postprocess
 
-scp_crawl: data/scp_titles.json data/scp_hubs.json data/scp_items.json data/scp_tales.json data/goi.json
+scp_crawl: data/scp_titles.json data/scp_hubs.json data/scp_items.json data/scp_tales.json data/goi.json data/scp_supplement.json
 
 data/scp_titles.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl scp_titles -o data/scp_titles.json
@@ -37,12 +37,19 @@ goi: data/goi.json
 data/goi.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl goi -o data/goi.json
 
-supplement: data/scp_supplement.json
+supplement: supplement_crawl supplement_postprocess
+
+supplement_crawl: data/scp_supplement.json
 
 data/scp_supplement.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl scp_supplement -o data/scp_supplement.json
 
-scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales
+supplement_postprocess: supplement_crawl data/processed/supplement
+
+data/processed/supplement: .venv
+	$(PYTHON_VENV) python -m scp_crawler.postprocessing run-postproc-supplement
+
+scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales data/processed/supplement
 
 data/processed/goi: .venv
 	$(PYTHON_VENV) python -m scp_crawler.postprocessing run-postproc-goi

--- a/scp_crawler/items.py
+++ b/scp_crawler/items.py
@@ -33,6 +33,10 @@ class ScpGoi(WikiPage):
     pass
 
 
+class ScpSupplement(WikiPage):
+    pass
+
+
 class ScpTitle(scrapy.Item):
     title = scrapy.Field()
     scp = scrapy.Field()

--- a/scp_crawler/postprocessing.py
+++ b/scp_crawler/postprocessing.py
@@ -112,7 +112,7 @@ for hub in tqdm(
     hub_list,
 ):
     # Convert history dict to list and sort by date.
-    hub["history"] = process_history(hub["history"])
+    hub["history"] = process_history(hub.get("history"))
 
     if len(hub["history"]) > 0:
         hub["created_at"] = hub["history"][0]["date"]
@@ -161,7 +161,7 @@ def run_postproc_items():
         item["hubs"] = get_hubs(item["link"])
 
         # Convert history dict to list and sort by date.
-        item["history"] = process_history(item["history"])
+        item["history"] = process_history(item.get("history"))
 
         if len(item["history"]) > 0:
             item["created_at"] = item["history"][0]["date"]

--- a/scp_crawler/spiders/scp.py
+++ b/scp_crawler/spiders/scp.py
@@ -343,7 +343,7 @@ class ScpTaleSpider(CrawlSpider, WikiMixin):
 
     rules = (
         Rule(LinkExtractor(allow=[re.escape("tales-by-title"), re.escape("system:page-tags/tag/tale")])),
-        Rule(LinkExtractor(deny=[r"system:.*", r".*:.*", re.escape("tag-search")]), callback="parse_tale"),
+        Rule(LinkExtractor(allow=[r".*"]), callback="parse_tale"),
     )
 
     def parse_tale(self, response, original_link=None):

--- a/scp_crawler/spiders/scp.py
+++ b/scp_crawler/spiders/scp.py
@@ -343,7 +343,7 @@ class ScpTaleSpider(CrawlSpider, WikiMixin):
 
     rules = (
         Rule(LinkExtractor(allow=[re.escape("tales-by-title"), re.escape("system:page-tags/tag/tale")])),
-        Rule(LinkExtractor(allow=[r".*"]), callback="parse_tale"),
+        Rule(LinkExtractor(deny=[r"system:.*", r".*:.*", re.escape("tag-search")]), callback="parse_tale"),
     )
 
     def parse_tale(self, response, original_link=None):

--- a/scp_crawler/spiders/scp.py
+++ b/scp_crawler/spiders/scp.py
@@ -1,3 +1,4 @@
+import json
 import re
 import sys
 from pprint import pprint
@@ -29,12 +30,65 @@ class WikiMixin:
 
         page_id = item["page_id"]
         changes = item["history"] if "history" in item else {}
+
         try:
+            response_text = getattr(response, "text", "") or ""
+            if not response_text.strip():
+                self.logger.error(
+                    "Empty response when fetching history for %s (status=%s, page=%s)",
+                    item.get("url"),
+                    getattr(response, "status", None),
+                    history_page,
+                )
+                return self.get_page_source_request(page_id, item)
+
             history = response.json()
-            soup = BeautifulSoup(history["body"], "lxml")
+            if not isinstance(history, dict) or "body" not in history:
+                self.logger.error(
+                    "Missing 'body' in history lookup for %s (status=%s, page=%s). Keys=%s",
+                    item.get("url"),
+                    getattr(response, "status", None),
+                    history_page,
+                    list(history.keys()) if isinstance(history, dict) else type(history),
+                )
+                return self.get_page_source_request(page_id, item)
+
+            body = history.get("body")
+            if not body:
+                self.logger.error(
+                    "Empty 'body' in history lookup for %s (status=%s, page=%s)",
+                    item.get("url"),
+                    getattr(response, "status", None),
+                    history_page,
+                )
+                return self.get_page_source_request(page_id, item)
+
+            soup = BeautifulSoup(body, "lxml")
+            if soup.table is None:
+                self.logger.error(
+                    "Missing <table> in history HTML for %s (status=%s, page=%s)",
+                    item.get("url"),
+                    getattr(response, "status", None),
+                    history_page,
+                )
+                return self.get_page_source_request(page_id, item)
             rows = soup.table.find_all("tr")
-        except:
-            self.logger.exception(f"Unable to parse history lookup. {item['url']}")
+
+        except (json.JSONDecodeError, ValueError):
+            self.logger.error(
+                "JSON decode error in history lookup for %s (status=%s, page=%s)",
+                item.get("url"),
+                getattr(response, "status", None),
+                history_page,
+            )
+            return self.get_page_source_request(page_id, item)
+        except Exception:
+            self.logger.exception(
+                "Unable to parse history lookup for %s (status=%s, page=%s)",
+                item.get("url"),
+                getattr(response, "status", None),
+                history_page,
+            )
             return self.get_page_source_request(page_id, item)
         for row in rows:
             try:


### PR DESCRIPTION
This PR adds first-class support for “supplement” pages from the SCP Wiki and integrates them into the existing crawl + post-processing workflow.

- Adds a new Scrapy spider `scp_supplement` to crawl pages tagged supplement and export them to `scp_supplement.json`.
- Introduces the ScpSupplement item type.
- Extends post-processing with `run_postproc_supplement` to generate processed outputs under supplement:
- `content_supplement.json `(full content + history/source/images)
- `index.json` (metadata + content_file)
- Adds `parent_scp` (best-effort extracted from the link) and parent_tale (best-effort extracted from *-<number> patterns).
- Updates the Makefile so Supplements are included in `scp_crawl` and `scp_postprocess` (and still available via dedicated `supplement_*` targets).
- Updates README documentation to mention the new spider, output file, and processed output.

## How to test

- `make scp` (includes supplements crawl + postprocess)

Or individually:
- `make supplement_crawl`
- `make supplement_postprocess`
- `scrapy crawl scp_supplement -o data/scp_supplement.json`

This PR should fix #2 