### PR TITLE
feature/add supplements: Adds first-class support for "supplement" pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 
 *.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,9 +32,15 @@ To crawl the International Hub for SCP Items and save to a custom location:
 scrapy crawl scp_int -o scp_international_items.json
 ```
 
+To crawl pages tagged as `supplement` and save to a custom location:
+
+```bash
+scrapy crawl scp_supplement -o scp_supplement.json
+```
+
 ## Raw Content Structure
 
-There are two types of content downloaded- SCP Items and SCP Tales.
+There are multiple types of content downloaded (Items, Tales, GOI formats, and Supplements).
 
 All content (both SCP Items and Tales) contain the following:
 
@@ -66,6 +72,7 @@ The crawler generates a series of json files containing an array of objects repr
 | scp_titles.json     | Main          | Title | scp     |
 | scp_hubs.json       | Main          | Hub   | scp     |
 | scp_tales.json      | Main          | Tale  | scp     |
+| scp_supplement.json | Main          | Supplement | scp |
 | scp_int.json        | International | Item  | scp_int |
 | scp_int_titles.json | International | Title | scp_int |
 | scp_int_tales.json  | International | Tale  | scp_int |
@@ -76,7 +83,9 @@ To regenerate all files run `make fresh`.
 
 ## Post Processed Data
 
-The postproc system takes the Titles, Hubs, Items, and Tales and uses them to generate a comprehensive set of objects. It combines and cross references data and expands on the data already there.
+The postproc system takes Titles, Hubs, Items, Tales, GOI, and Supplements and uses them to generate a comprehensive set of objects. It combines and cross references data and expands on the data already there.
+
+Supplements are written to `data/processed/supplement/` and include additional fields like `parent_scp` and `parent_tale`.
 
 
 ## Content Licensing

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ PYTHON_VENV = source .venv/bin/activate &&
 
 install: .venv
 
-data: scp scp_int goi
+data: scp scp_int goi supplement
 
 fresh: clean data
 
@@ -14,7 +14,7 @@ clean:
 	python -m venv .venv
 	$(PYTHON_VENV) python -m pip install .
 
-crawl: scp scp_int goi
+crawl: scp scp_int goi supplement
 
 scp: scp_crawl scp_postprocess
 
@@ -36,6 +36,11 @@ goi: data/goi.json
 
 data/goi.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl goi -o data/goi.json
+
+supplement: data/scp_supplement.json
+
+data/scp_supplement.json: .venv
+	$(PYTHON_VENV) python -m scrapy crawl scp_supplement -o data/scp_supplement.json
 
 scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ PYTHON_VENV = source .venv/bin/activate &&
 
 install: .venv
 
-data: scp scp_int goi supplement
+data: scp scp_int goi
 
 fresh: clean data
 
@@ -14,11 +14,11 @@ clean:
 	python -m venv .venv
 	$(PYTHON_VENV) python -m pip install .
 
-crawl: scp scp_int goi supplement
+crawl: scp scp_int goi
 
 scp: scp_crawl scp_postprocess
 
-scp_crawl: data/scp_titles.json data/scp_hubs.json data/scp_items.json data/scp_tales.json data/goi.json
+scp_crawl: data/scp_titles.json data/scp_hubs.json data/scp_items.json data/scp_tales.json data/goi.json data/scp_supplement.json
 
 data/scp_titles.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl scp_titles -o data/scp_titles.json
@@ -37,12 +37,19 @@ goi: data/goi.json
 data/goi.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl goi -o data/goi.json
 
-supplement: data/scp_supplement.json
+supplement: supplement_crawl supplement_postprocess
+
+supplement_crawl: data/scp_supplement.json
 
 data/scp_supplement.json: .venv
 	$(PYTHON_VENV) python -m scrapy crawl scp_supplement -o data/scp_supplement.json
 
-scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales
+supplement_postprocess: supplement_crawl data/processed/supplement
+
+data/processed/supplement: .venv
+	$(PYTHON_VENV) python -m scp_crawler.postprocessing run-postproc-supplement
+
+scp_postprocess: scp_crawl data/processed/goi data/processed/items data/processed/tales data/processed/supplement
 
 data/processed/goi: .venv
 	$(PYTHON_VENV) python -m scp_crawler.postprocessing run-postproc-goi

--- a/scp_crawler/items.py
+++ b/scp_crawler/items.py
@@ -33,6 +33,10 @@ class ScpGoi(WikiPage):
     pass
 
 
+class ScpSupplement(WikiPage):
+    pass
+
+
 class ScpTitle(scrapy.Item):
     title = scrapy.Field()
     scp = scrapy.Field()


### PR DESCRIPTION
## Description
Adds first-class support for "supplement" pages from the SCP Wiki, enabling automated crawling and post-processing of supplementary content.

## Changes
- **New Item Type**: `ScpSupplement` class in `items.py`
- **New Spider**: `ScpSupplementSpider` to crawl pages tagged with `supplement` from `https://scp-wiki.wikidot.com/system:page-tags/tag/supplement`
- **Post-Processing**: `run_postproc_supplement()` command that:
  - Extracts parent SCP references (e.g., "SCP-6881" from link)
  - Extracts parent tale series (e.g., "planetfall" from `planetfall-7`)
  - Processes history, images, and hub references
  - Outputs to `data/processed/supplement/` with `index.json` and `content_supplement.json`
- **Makefile Integration**: Supplements now included in `scp_crawl` and `scp_postprocess` targets
- **Documentation**: Updated README with supplement spider usage and output structure

## Output Structure
```json
{
  "planetfall-7": {
    "title": "Planetfall: 7",
    "parent_scp": null,
    "parent_tale": "planetfall",
    "created_at": "2023-05-15T14:30:00",
    ...
  }
}
```

### Testing
```sh
make supplement              # Crawl + post-process
scrapy crawl scp_supplement  # Crawl only
```